### PR TITLE
First pass of adding Leaflet.js to page

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,4 @@
+class MapsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,2 @@
 class PagesController < ApplicationController
-  def index
-  end
 end

--- a/app/views/layouts/maps.html.erb
+++ b/app/views/layouts/maps.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ShortageTracker</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <!-- Begin Leaflet stuff -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
+      integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+      crossorigin=""/>
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
+      integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
+      crossorigin=""></script>
+    <!-- END Leaflet stuff -->
+  </head>
+
+  <body>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,15 @@
+<h1>Maps#index</h1>
+<style>
+#map-container {
+  height: 500px;
+}
+</style>
+<div id="map-container"></div>
+
+<script>
+  var mymap = L.map('map-container').setView([22.27583223, 114.154832714], 13);
+  L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png', {
+    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery by Wikimedia Foundation ',
+    maxZoom: 18,
+}).addTo(mymap);
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :privileges
   resources :roles
   devise_for :users
-  root to: "pages#index"
-  get 'pages/index'
+  root to: "maps#index"
+  get 'maps/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Tiles from Wikimedia's map server which are free as in beer, as long as we follow the policy (Should automagically send `HTTP-Referrer` correctly with real values once it's deployed live).

![image](https://user-images.githubusercontent.com/2475615/73520326-3a565000-43b8-11ea-8cdc-0df4ef0ed1ed.png)

I added a separate layout that pulls in `Leaflet` assets from the CDN so we're only loading it on pages where we need it. Might be overkill since we'll probably just have one map on the homepage but we can refactor later.

To test:
1. pull branch
2. `rails s`
3. `localhost:3000`