### PR TITLE
Add i18n for en and zh-CN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'rails-i18n'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,6 @@ gem "activerecord-postgis-adapter", "~> 6.0"
 
 # Added at 2020-02-04 10:27:10 +0800 by nathanhammond:
 gem "redis", "~> 4.1"
+
+# Added at 2020-02-06 01:16:24.876275 by thehapax:
+gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.9.0)
+      devise (>= 4.7.1)
     erubi (1.9.0)
     ffi (1.12.1)
     globalid (0.4.2)
@@ -228,6 +230,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise (~> 4.7)
+  devise-i18n
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -231,6 +234,7 @@ DEPENDENCIES
   puma (~> 4.1)
   pundit (~> 2.1)
   rails (~> 6.0.2, >= 6.0.2.1)
+  rails-i18n
   redis (~> 4.1)
   sass-rails (>= 6)
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -38,22 +38,6 @@ bundle install
 
 rake db:create && rake db:migrate
 
-# if error from rake db create
-could not connect to server: No such file or directory
-	Is the server running locally and accepting
-	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
-Couldn't create 'shortage_tracker_development' database. Please check your configuration.
-rake aborted!
-PG::ConnectionBad: could not connect to server: No such file or directory
-	Is the server running locally and accepting
-	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
-
-Tasks: TOP => db:create
-(See full trace by running task with --trace)
-
-# do the following to fix: 
-https://stackoverflow.com/questions/13573204/psql-could-not-connect-to-server-no-such-file-or-directory-mac-os-x#13573207
-
 rails s
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bundle install
 
 rake db:create && rake db:migrate
 
-# if error: 
+# if error from rake db create
 could not connect to server: No such file or directory
 	Is the server running locally and accepting
 	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
@@ -51,9 +51,7 @@ Tasks: TOP => db:create
 (See full trace by running task with --trace)
 
 # do the following to fix: 
-
-
-
+https://stackoverflow.com/questions/13573204/psql-could-not-connect-to-server-no-such-file-or-directory-mac-os-x#13573207
 
 rails s
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a project of OSINThk.
 
 ## Setup
 
+Good Guide to [`How to install Ruby on Rails with rbenv on macOS `](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-macos)
+ 
 Works with [`rbenv`](https://github.com/rbenv/rbenv#homebrew-on-macos). May work with `rvm`.
 
 An approximate macOS setup from basics:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a project of OSINThk.
 
 ## Setup
 
-Good Guide to [`How to install Ruby on Rails with rbenv on macOS `](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-macos)
+If new to Ruby, this is a Good Guide to [`How to install Ruby on Rails with rbenv on macOS `](https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-macos)
  
 Works with [`rbenv`](https://github.com/rbenv/rbenv#homebrew-on-macos). May work with `rvm`.
 
@@ -15,15 +15,45 @@ brew install git rbenv postgres postgis
 
 brew services start postgresql
 
+# do in this order
 rbenv init
 rbenv install 2.5.1
 gem install bundler rails
 
 git clone git@github.com:OSINThk/shortage-tracker.git
 cd shortage-tracker
+
+# check to make sure that the versions are correct before doing bundle install
+$ ruby -v
+$ rails -v
+
+# if rails -v fails, with error message: Gem::GemNotFoundException, update gems
+$ gem update --system
+
 bundle install
 
+# check to make sure your yarn packages are up to date
+# $ yarn install --check-files
+
 rake db:create && rake db:migrate
+
+# if error: 
+could not connect to server: No such file or directory
+	Is the server running locally and accepting
+	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
+Couldn't create 'shortage_tracker_development' database. Please check your configuration.
+rake aborted!
+PG::ConnectionBad: could not connect to server: No such file or directory
+	Is the server running locally and accepting
+	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
+
+Tasks: TOP => db:create
+(See full trace by running task with --trace)
+
+# do the following to fix: 
+
+
+
 
 rails s
 ```

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,15 @@
 class ApplicationController < ActionController::Base
+  before_action :set_locale
   include Pundit
 
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
+  end
+  
   private
     def initialize
       # Counter that is reset per request.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,14 @@ class ApplicationController < ActionController::Base
   def default_url_options
     { locale: I18n.locale }
   end
-  
+
+  def browser_locale(request)
+   locales = request.env['HTTP_ACCEPT_LANGUAGE'] || ""
+   locales.scan(/[a-z]{2}(?=;)/).find do |locale|
+     I18n.available_locales.include?(locale.to_sym)
+   end
+  end
+    
   private
     def initialize
       # Counter that is reset per request.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Shortage Tracker</title>
+    <title><%=t('shortage_tracker')%></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/maps.html.erb
+++ b/app/views/layouts/maps.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Shortage Tracker</title>
+    <title><%= t('shortage_tracker') %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,3 +1,12 @@
+<p>
+<% if current_user %>
+    <%= t('login_status', username: current_user.email) %>
+<% end %>
+</p>
+
+<p> locale: <%= t('lang') %></p>
+<p><%= l Time.now, format: :short %></p>
+
 <h2>Instructions</h2>
 <% if current_user.nil? %>
   <p>Please <%= link_to 'sign in', new_user_session_path %> to add a report to the map.</p>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,19 +1,19 @@
 <p>
 <% if current_user %>
-    <%= t('login_status', username: current_user.email) %>
+    <%= t('.login_status', username: current_user.email) %>
 <% end %>
 </p>
 
-<p> locale: <%= t('lang') %></p>
+<p> locale: <%= t('.lang') %></p>
 <p> <%= l Time.now, format: :short %></p>
 
-<h2><%= t('instruct_title') %></h2>
+<h2><%= t('.instruct_title') %></h2>
 <% if current_user.nil? %>
-  <p><%= t('signin_msg') %> <%= link_to t('login'), new_user_session_path %> <%= t('signin_msg_2') %></p>
+  <p><%= t('.signin_msg') %> <%= link_to t('login'), new_user_session_path %> <%= t('.signin_msg_2') %></p>
   <% else %>
   
-<p>    <%= t('instruct_body') %>
-  <%= link_to t('instruct_body_2'), new_report_path %>.</p>
+<p>    <%= t('.instruct_body') %>
+  <%= link_to t('.instruct_body_2'), new_report_path %>.</p>
 <% end %>
 
 <style>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -4,8 +4,12 @@
 <% end %>
 </p>
 
-<p> locale: <%= t('.lang') %></p>
-<p> <%= l Time.now, format: :short %></p>
+<p><%= link_to "English", { :locale=>'en' } %> |
+  <%= link_to "中文", { :locale=>'zh-CN' } %>
+</p>
+
+<p>  <%= t('locale_label') %> <%= t('.lang') %> </p>
+<p>  <%= t('time_label') %> <%= l Time.now, format: :short %></p>
 
 <h2><%= t('.instruct_title') %></h2>
 <% if current_user.nil? %>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -5,13 +5,15 @@
 </p>
 
 <p> locale: <%= t('lang') %></p>
-<p><%= l Time.now, format: :short %></p>
+<p> <%= l Time.now, format: :short %></p>
 
-<h2>Instructions</h2>
+<h2><%= t('instruct_title') %></h2>
 <% if current_user.nil? %>
-  <p>Please <%= link_to 'sign in', new_user_session_path %> to add a report to the map.</p>
-<% else %>
-  <p>Press anywhere on the map to add a report. Alternatively, <%= link_to 'add a report using your device location', new_report_path %>.</p>
+  <p><%= t('signin_msg') %> <%= link_to t('login'), new_user_session_path %> <%= t('signin_msg_2') %></p>
+  <% else %>
+  
+<p>    <%= t('instruct_body') %>
+  <%= link_to t('instruct_body_2'), new_report_path %>.</p>
 <% end %>
 
 <style>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,10 +1,3 @@
-<h2>About</h2>
-
-<p>Shortage tracker is a project of <a href="https://www.osinthk.org/">OSINT HK</a>. We are grateful for your support and interest. Get in touch with us about this project at <a href="mailto:shortage-tracker@ostinthk.org">shortage-tracker@ostinthk.org</a>.</p>
-
-<p>Shortage Tracker is an Open Source project. <a href="https://github.com/OSINThk/shortage-tracker">You can find the code for this project on GitHub.</a></p>
-
-
 <h2> 关于</h2>
 <p>
   短缺跟踪器是<a href="https://www.osinthk.org/">OSINT HK</a>的一个项目。 我们感谢您的支持和关注。 与我们联系有关此项目的电子邮件，短缺程度为tracker@ostinthk.org 。</p>
@@ -13,3 +6,12 @@
   Shortage Tracker是一个开源项目。 您可以在<a href="https://github.com/OSINThk/shortage-tracker">
     GitHub</a>上找到该项目的代码。
   </p>
+
+
+<h2>About</h2>
+
+<p>Shortage tracker is a project of <a href="https://www.osinthk.org/">OSINT HK</a>. We are grateful for your support and interest. Get in touch with us about this project at <a href="mailto:shortage-tracker@ostinthk.org">shortage-tracker@ostinthk.org</a>.</p>
+
+<p>Shortage Tracker is an Open Source project. <a href="https://github.com/OSINThk/shortage-tracker">You can find the code for this project on GitHub.</a></p>
+
+

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -3,3 +3,13 @@
 <p>Shortage tracker is a project of <a href="https://www.osinthk.org/">OSINT HK</a>. We are grateful for your support and interest. Get in touch with us about this project at <a href="mailto:shortage-tracker@ostinthk.org">shortage-tracker@ostinthk.org</a>.</p>
 
 <p>Shortage Tracker is an Open Source project. <a href="https://github.com/OSINThk/shortage-tracker">You can find the code for this project on GitHub.</a></p>
+
+
+<h2> 关于</h2>
+<p>
+  短缺跟踪器是<a href="https://www.osinthk.org/">OSINT HK</a>的一个项目。 我们感谢您的支持和关注。 与我们联系有关此项目的电子邮件，短缺程度为tracker@ostinthk.org 。</p>
+
+<p>
+  Shortage Tracker是一个开源项目。 您可以在<a href="https://github.com/OSINThk/shortage-tracker">
+    GitHub</a>上找到该项目的代码。
+  </p>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,18 +1,18 @@
-<h1><%= link_to 'Shortage Tracker', root_path %></h1>
+<h1><%= link_to t('shortage_tracker'), root_path %></h1>
 <nav>
   <ul>
     <% if policy(:pages).admin? %>
       <li><%= link_to 'Admin', admin_path %></li>
     <% end %>
     <% if current_user.nil? %>
-      <li><%= link_to 'Sign Up', new_user_registration_path %></li>
-      <li><%= link_to 'Sign In', new_user_session_path %></li>
+      <li><%= link_to t('signup'), new_user_registration_path %></li>
+      <li><%= link_to t('login'), new_user_session_path %></li>
     <% else %>
-      <li><%= link_to 'New Report', new_report_path %></li>
-      <li><%= link_to 'My Reports', reports_path %></li>
-      <li><%= link_to 'Sign Out', destroy_user_session_path %></li>
+      <li><%= link_to t('new_report'), new_report_path %></li>
+      <li><%= link_to t('my_reports'), reports_path %></li>
+      <li><%= link_to t('logout'), destroy_user_session_path %></li>
     <% end %>
-    <li><%= link_to 'About', about_path %></li>
+    <li><%= link_to t('about'), about_path %></li>
   </ul>
 </nav>
 <p id="notice"><%= notice %></p>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,3 +1,4 @@
+
 <h1><%= link_to t('shortage_tracker'), root_path %></h1>
 <nav>
   <ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -11,25 +11,25 @@
     </div>
   <% end %>
 
-  <button type="button" class="find-me">Populate Location</button>
+  <button type="button" class="find-me"><%= t('.populate_location_label') %></button>
 
   <div class="field">
-    <%= form.label :lat, "Latitude" %>
+    <%= form.label :lat, t('.latitude') %>
     <%= form.text_field :lat %>
   </div>
 
   <div class="field">
-    <%= form.label :long, "Longitude" %>
+    <%= form.label :long, t('.longitude') %>
     <%= form.text_field :long %>
   </div>
 
   <div class="field">
-    <%= form.label :notes %>
+    <%= form.label  t('.latlon_notes') %>
     <%= form.text_field :notes %>
   </div>
 
   <section class="form-section">
-    <h3>Products</h3>
+    <h3><%= t('.products_title') %></h3>
     <ul class="form-section__card-stack">
       <%= form.fields_for :product_detail do |product_detail_form| %>
         <li class="form-section__card form-section__product-detail-card">
@@ -46,7 +46,7 @@
             </li>
           <% end %>
         </template>
-        <button type="button" class="add-relationship" data-slug="<%= formslug %>">Add Product Detail</button>
+        <button type="button" class="add-relationship" data-slug="<%= formslug %>"><%= t('.add_product_detail') %></button>
       </li>
     </ul>
   </section>

--- a/app/views/reports/_product_details_fields.erb
+++ b/app/views/reports/_product_details_fields.erb
@@ -1,26 +1,26 @@
 <%= form.hidden_field :_destroy, { value: "false", class: "destroy" } %>
-<button type="button" class="remove-relationship">Remove Product Details</button>
+<button type="button" class="remove-relationship"><%= t('.del_product_detail') %></button>
 
 <div class="field">
-  <%= form.label :product_id %>
-  <%= form.select :product_id, products.map { |product| [product, product.id] }, { include_blank: "Select product..." } %>
+  <%= form.label t('.product_label') %>
+  <%= form.select :product_id, products.map { |product| [product, product.id] }, { include_blank: t('.select_product_label')  } %>
 </div>
 
 <div class="field">
-  <%= form.label :scarcity %>
-  Normal
+  <%= form.label  t('.scarcity_label')  %>
+   <%= t('.normal_label') %>
   <%= form.range_field :scarcity, :in => 1..5, :step => '1' %>
-  None
+   <%= t('.none_label') %>
 </div>
 
 <div class="field">
-  <%= form.label :price %>
-  Normal
+  <%= form.label t('.price_label') %>
+   <%= t('.normal_label') %>
   <%= form.range_field :price, :in => 1..5, :step => '1' %>
-  Expensive
+   <%= t('.expensive_label') %>
 </div>
 
 <div class="field">
-  <%= form.label :notes %>
+  <%= form.label t('.note_label')  %>
   <%= form.text_field :notes %>
 </div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Reports</h2>
+<h2><%= t('.report_title') %></h2>
 
 <% if @reports.length > 0 %>
   <table>
@@ -30,5 +30,6 @@
 
 <%= link_to 'New Report', new_report_path %>
 <% else %>
-  <p>You have not yet created a report. <%= link_to 'Create your first report now.', new_report_path %></p>
+<p><%= t('.report_msg1') %>
+  <%= link_to t('.create_msg'), new_report_path %></p>
 <% end %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,5 +1,5 @@
-<h2>New Report</h2>
+<h2><%= t('.new_report') %> </h2>
 
 <%= render 'form', report: @report, products: @products %>
 
-<%= link_to 'Back', reports_path %>
+<%= link_to t('.back_link_label'), reports_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module ShortageTracker
     config.load_defaults 6.0
     config.redis = config_for(:redis)
 
+    config.i18n.default_locale = :en
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -1,0 +1,70 @@
+# Chinese (China) translations for Devise 4.2.1
+# 4.2.0: By HealthGrid at https://gist.github.com/HealthGrid/2d702b38aa6ffe0233f27d3d5be9250f
+# 4.2.1: By Artoria2e5 (this file)
+#  - Fixes pluralization problems (zh only takes "other")
+#  - Misc translation improvements, you know what these grammar things are.
+#  - Should be minor enough to claim CC0 for my changes.
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+zh-CN:
+  devise:
+    confirmations:
+      confirmed: "成功验证您的帐号。您现已登录。"
+      send_instructions: "您的电子邮箱将在几分钟后收到一封帐号确认邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封确认帐号的邮件。"
+    failure:
+      already_authenticated: "您已经登录。"
+      inactive: "您还没有激活帐户。"
+      invalid: "邮箱或密码错误。"
+      locked: "您的帐号已被锁定。"
+      last_attempt: "您还有最后一次尝试机会，再次失败您的帐号将被锁定。"
+      not_found_in_database: "邮箱或密码错误。"
+      timeout: "您已登录超时，请重新登录。"
+      unauthenticated: "继续操作前请注册或者登录。"
+      unconfirmed: "继续操作前请先确认您的帐号。"
+    mailer:
+      confirmation_instructions:
+        subject: "帐户确认信息"
+      reset_password_instructions:
+        subject: "重置密码信息"
+      unlock_instructions:
+        subject: "帐户解锁信息"
+      email_changed:
+        subject: "电邮已被修改"
+      password_change:
+        subject: '密码已被重置'
+    omniauth_callbacks:
+      failure: "由于%{reason}，无法从%{kind}获得授权。"
+      success: "成功地从%{kind}获得授权。"
+    passwords:
+      no_token: "无重置邮件不可访问密码重置页面。如果您是从重置邮件来到了这个页面，请确保您输入的URL完整的。"
+      send_instructions: "几分钟后，您将收到重置密码的电子邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封找回密码的邮件。"
+      updated: "您的密码已修改成功，您现在已登录。"
+      updated_not_active: "您的密码已修改成功。"
+    registrations:
+      destroyed: "再见！您的帐户已成功注销。我们希望很快可以再见到您。"
+      signed_up: "欢迎！您已注册成功。"
+      signed_up_but_inactive: "您已注册，但尚未激活帐号。"
+      signed_up_but_locked: "您已注册，但帐号被锁定了。"
+      signed_up_but_unconfirmed: "一封带有确认链接的邮件已经发送至您的邮箱，请检查邮箱（包括垃圾邮箱），并点击该链接激活您的帐号。"
+      update_needs_confirmation: "信息更新成功，但我们需要验证您的新电子邮件地址，请检查邮箱（包括垃圾邮箱），并点击该链接激活您的帐号。"
+      updated: "帐号资料更新成功。"
+      updated_but_not_signed_in: "帐号资料更新成功。由于密码已修改，请重新登录。"
+    sessions:
+      signed_in: "登录成功。"
+      signed_out: "退出成功。"
+      already_signed_out: "已经退出成功。"
+    unlocks:
+      send_instructions: "几分钟后，您将收到一封解锁帐号的邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封解锁帐号的邮件。"
+      unlocked: "您的帐号已成功解锁，您现在已登录。"
+  errors:
+    messages:
+      already_confirmed: "已经确认，请重新登录。"
+      confirmation_period_expired: "注册帐号后须在%{period}以内确认。请重新注册。"
+      expired: "邮件确认已过期，请重新注册。"
+      not_found: "找不到。"
+      not_locked: "未锁定。"
+      not_saved:
+        other: "发生%{count}个错误，导致%{resource}保存失败："

--- a/config/locales/devise.zh-HK.yml
+++ b/config/locales/devise.zh-HK.yml
@@ -1,0 +1,70 @@
+# Chinese (China) translations for Devise 4.2.1
+# 4.2.0: By HealthGrid at https://gist.github.com/HealthGrid/2d702b38aa6ffe0233f27d3d5be9250f
+# 4.2.1: By Artoria2e5 (this file)
+#  - Fixes pluralization problems (zh only takes "other")
+#  - Misc translation improvements, you know what these grammar things are.
+#  - Should be minor enough to claim CC0 for my changes.
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+zh-CN:
+  devise:
+    confirmations:
+      confirmed: "成功验证您的帐号。您现已登录。"
+      send_instructions: "您的电子邮箱将在几分钟后收到一封帐号确认邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封确认帐号的邮件。"
+    failure:
+      already_authenticated: "您已经登录。"
+      inactive: "您还没有激活帐户。"
+      invalid: "邮箱或密码错误。"
+      locked: "您的帐号已被锁定。"
+      last_attempt: "您还有最后一次尝试机会，再次失败您的帐号将被锁定。"
+      not_found_in_database: "邮箱或密码错误。"
+      timeout: "您已登录超时，请重新登录。"
+      unauthenticated: "继续操作前请注册或者登录。"
+      unconfirmed: "继续操作前请先确认您的帐号。"
+    mailer:
+      confirmation_instructions:
+        subject: "帐户确认信息"
+      reset_password_instructions:
+        subject: "重置密码信息"
+      unlock_instructions:
+        subject: "帐户解锁信息"
+      email_changed:
+        subject: "电邮已被修改"
+      password_change:
+        subject: '密码已被重置'
+    omniauth_callbacks:
+      failure: "由于%{reason}，无法从%{kind}获得授权。"
+      success: "成功地从%{kind}获得授权。"
+    passwords:
+      no_token: "无重置邮件不可访问密码重置页面。如果您是从重置邮件来到了这个页面，请确保您输入的URL完整的。"
+      send_instructions: "几分钟后，您将收到重置密码的电子邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封找回密码的邮件。"
+      updated: "您的密码已修改成功，您现在已登录。"
+      updated_not_active: "您的密码已修改成功。"
+    registrations:
+      destroyed: "再见！您的帐户已成功注销。我们希望很快可以再见到您。"
+      signed_up: "欢迎！您已注册成功。"
+      signed_up_but_inactive: "您已注册，但尚未激活帐号。"
+      signed_up_but_locked: "您已注册，但帐号被锁定了。"
+      signed_up_but_unconfirmed: "一封带有确认链接的邮件已经发送至您的邮箱，请检查邮箱（包括垃圾邮箱），并点击该链接激活您的帐号。"
+      update_needs_confirmation: "信息更新成功，但我们需要验证您的新电子邮件地址，请检查邮箱（包括垃圾邮箱），并点击该链接激活您的帐号。"
+      updated: "帐号资料更新成功。"
+      updated_but_not_signed_in: "帐号资料更新成功。由于密码已修改，请重新登录。"
+    sessions:
+      signed_in: "登录成功。"
+      signed_out: "退出成功。"
+      already_signed_out: "已经退出成功。"
+    unlocks:
+      send_instructions: "几分钟后，您将收到一封解锁帐号的邮件。"
+      send_paranoid_instructions: "如果您的邮箱存在于我们的数据库中，您将收到一封解锁帐号的邮件。"
+      unlocked: "您的帐号已成功解锁，您现在已登录。"
+  errors:
+    messages:
+      already_confirmed: "已经确认，请重新登录。"
+      confirmation_period_expired: "注册帐号后须在%{period}以内确认。请重新注册。"
+      expired: "邮件确认已过期，请重新注册。"
+      not_found: "找不到。"
+      not_locked: "未锁定。"
+      not_saved:
+        other: "发生%{count}个错误，导致%{resource}保存失败："

--- a/config/locales/devise.zh-TW.yml
+++ b/config/locales/devise.zh-TW.yml
@@ -1,0 +1,71 @@
+# Chinese (Taiwan) translations for Devise 4.2.1
+# 4.1.1: By MitsunChieh at https://gist.github.com/MitsunChieh/8b4249859274acd15df5f4d757e55bc2
+# 4.2.1: By Artoria2e5 (this file)
+#  - Fixes pluralization problems (zh only takes "other")
+#  - Misc translation improvements, you know what these grammar things are
+#    - Actually a lot?
+#  - Should be minor enough to claim CC0 for my changes.
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+zh-TW:
+  devise:
+    confirmations:
+      confirmed: "您的帳號已通過驗證，現在您已成功登入。"
+      send_instructions: "您將在幾分鐘後收到一封電子郵件，內有驗證帳號的步驟說明。"
+      send_paranoid_instructions: "如果我們有您的信箱，您將會收到一封驗證您的帳號的電子郵件。"
+    failure:
+      already_authenticated: "您已經登入。"
+      inactive: "您的帳號尚未被啟用。"
+      invalid: "信箱或密碼是無效的。"
+      locked: "您的帳號已被鎖定。"
+      last_attempt: "您還有最後一次嘗試機會，再次失敗您的帳號將會被鎖定。"
+      not_found_in_database: "信箱或密碼是無效的。"
+      timeout: "您的登入時效過期，請重新登入。"
+      unauthenticated: "您需要先登入或註冊後才能繼續。"
+      unconfirmed: "您的帳號需需要經過驗證後，才能繼續。"
+    mailer:
+      confirmation_instructions:
+        subject: "帳號驗證步驟"
+      reset_password_instructions:
+        subject: "密碼重設步驟"
+      unlock_instructions:
+        subject: "帳號解鎖步驟"
+      email_changed:
+        subject: "信箱已被修改"
+      password_change:
+        subject: "密碼已被修改"
+    omniauth_callbacks:
+      failure: "無法從 %{kind} 驗證，因為「%{reason}」。"
+      success: "成功從 %{kind} 驗證。"
+    passwords:
+      no_token: "這是密碼重設頁面，僅能透過密碼重設信件進入。如果您是透過重設信件進入的，請確認您的網址是完整的。"
+      send_instructions: "您將在幾分鐘後收到一封電子郵件，內有重新設定密碼的步驟說明。"
+      send_paranoid_instructions: "如果我們有您的信箱，您將會收到一封內含可重新設定密碼連結的電子郵件。"
+      updated: "您的密碼已被修改，您現在已經登入。"
+      updated_not_active: "您的密碼已被修改。"
+    registrations:
+      destroyed: "再會！您的帳號已被取消。有緣再會。"
+      signed_up: "註冊成功，歡迎！"
+      signed_up_but_inactive: "您已註冊成功。然而因為您的帳號尚未啓動，暫時無法登入，抱歉！"
+      signed_up_but_locked: "您已註冊成功。 然而因為您的帳號已被鎖定，暫時無法登入，抱歉！"
+      signed_up_but_unconfirmed: "確認信件已送至您的 Email 信箱，請點擊信件內連結以啓動您的帳號。"
+      update_needs_confirmation: "您已經成功的更新帳號資訊，但我們仍需確認您的電子信箱，請至新信箱收信並點擊連結以確認您的新電子郵件帳號。"
+      updated: "您已經成功的更新帳號資訊。"
+      updated_but_not_signed_in: "您已經成功的更新帳號資訊。但因為您變更了密碼，請重新登入。"
+    sessions:
+      signed_in: "成功登入了。"
+      signed_out: "成功登出了。"
+      already_signed_out: "成功登出了。"
+    unlocks:
+      send_instructions: "您將在幾分鐘後收到一封電子郵件，內有將帳號解除鎖定的步驟說明。"
+      send_paranoid_instructions: "如果您的帳號已存在，您的電子信箱將會收到如何解鎖帳號的指示。"
+      unlocked: "您的帳號已被解鎖，現在已經登入。"
+  errors:
+    messages:
+      already_confirmed: "已經驗證，請直接登入。"
+      confirmation_period_expired: "必須在 %{period} 內驗證，請重新申請。"
+      expired: "已經過期，請重新申請。"
+      not_found: "找不到。"
+      not_locked: "並未被鎖定。"
+      not_saved:
+        other: "有 %{count} 個錯誤導致 %{resource} 不能被儲存："

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,8 @@
 
 en:
   shortage_tracker: "Shortage Tracker"
+  locale_label: "your locale: "
+  time_label: "Current time: "
   login: "Login"
   logout: "Logout"
   reports:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+  lang: "en"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,8 @@
 en:
   hello: "Hello world"
   lang: "en"
+  instruct_title: "Instructions"
+  instruct_body: "Press anywhere on the map to add a report. Alternatively,"
+  instruct_body_2: "Or, add a report using your device location."
+  signin_msg: "Please"
+  signin_msg_2: "to add a report to the map."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,10 +30,44 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
-  lang: "en"
-  instruct_title: "Instructions"
-  instruct_body: "Press anywhere on the map to add a report. Alternatively,"
-  instruct_body_2: "Or, add a report using your device location."
-  signin_msg: "Please"
-  signin_msg_2: "to add a report to the map."
+  shortage_tracker: "Shortage Tracker"
+  login: "Login"
+  logout: "Logout"
+  reports:
+   new:
+     new_report: "New Report"
+     back_link_label: "Back"
+   form:
+     latitude: "Latitude"
+     longitude: "Longitude"
+     latlon_notes: "Notes"
+     products_title: "Products"
+     add_product_detail: "Add Product Detail"
+     populate_location_label: "Populate Location"
+   product_details_fields:
+     product_label: "Product"
+     scarcity_label: "Scarcity"
+     price_label: "Price"
+     note_label: "Notes"
+     normal_label: "Normal"
+     none_label: "None"
+     expensive_label: " Expensive"
+     select_product_label: "Select Product..."
+     del_product_detail: "Remove Product Detail"
+   index:
+     report_title: "Reports"
+     report_msg1: "You have not yet created a report."
+     create_msg: "Create your first report now."
+     location: "Location"
+     notes: "Notes"
+     report_time: "Report Time"
+  maps:
+    index:
+      lang: "en"
+      login_status: "Logged in as  %{username}"
+      instruct_title: "Instructions"
+      instruct_body: "Press anywhere on the map to add a report. Alternatively,"
+      instruct_body_2: "Or, add a report using your device location."
+      signin_msg: "Please"
+      signin_msg_2: "to add a report to the map."
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,220 @@
+---
+ja:
+  lang: "日本語"
+  signup: "登録する"
+  login: "ログイン"
+  logout: "ログアウト"
+  login_status: "%{username}としてログインしています。"
+  activerecord:
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        username: "ユーザー名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,186 @@
+---
+zh-CN:
+  lang: "zh-CN(简体中文)"
+  signup: "注册"
+  login: "登录"
+  logout: "登出"
+  login_status: "以 %{username} 身份登录"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: '验证失败: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 由于 %{record} 需要此记录，所以无法移除记录
+          has_many: 由于 %{record} 需要此记录，所以无法移除记录
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    - 
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 大约 %{count} 小时
+      about_x_months: 大约 %{count} 个月
+      about_x_years: 大约 %{count} 年
+      almost_x_years: 接近 %{count} 年
+      half_a_minute: 半分钟
+      less_than_x_seconds: 不到 %{count} 秒
+      less_than_x_minutes: 不到 %{count} 分钟
+      over_x_years: "%{count} 年多"
+      x_seconds: "%{count} 秒"
+      x_minutes: "%{count} 分钟"
+      x_days: "%{count} 天"
+      x_months: "%{count} 个月"
+      x_years: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 时
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: 必须是可被接受的
+      blank: 不能为空字符
+      confirmation: 与 %{attribute} 不匹配
+      empty: 不能留空
+      equal_to: 必须等于 %{count}
+      even: 必须为双数
+      exclusion: 是保留关键字
+      greater_than: 必须大于 %{count}
+      greater_than_or_equal_to: 必须大于或等于 %{count}
+      inclusion: 不包含于列表中
+      invalid: 是无效的
+      less_than: 必须小于 %{count}
+      less_than_or_equal_to: 必须小于或等于 %{count}
+      model_invalid: '验证失败: %{errors}'
+      not_a_number: 不是数字
+      not_an_integer: 必须是整数
+      odd: 必须为单数
+      other_than: 长度非法（不可为 %{count} 个字符
+      present: 必须是空白
+      required: 必须存在
+      taken: 已经被使用
+      too_long: 过长（最长为 %{count} 个字符）
+      too_short: 过短（最短为 %{count} 个字符）
+      wrong_length: 长度非法（必须为 %{count} 个字符）
+    template:
+      body: 如下字段出现错误：
+      header: 有 %{count} 个错误发生导致“%{model}”无法被保存。
+  helpers:
+    select:
+      prompt: 请选择
+    submit:
+      create: 新增%{model}
+      submit: 储存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十亿
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: 字节
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " 以及 "
+      two_words_connector: " 和 "
+      words_connector: "、"
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,6 +1,8 @@
 ---
 zh-CN:
   shortage_tracker: "短缺追踪器"
+  locale_label: "您的语言环境:"
+  time_label: "当前时间："
   login: "登录"
   logout: "登出"
   signup: "注册"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,19 +1,49 @@
 ---
 zh-CN:
-  lang: "zh-CN(简体中文)"
-  signup: "注册"
+  shortage_tracker: "短缺追踪器"
   login: "登录"
   logout: "登出"
-  login_status: "以 %{username} 身份登录"
+  signup: "注册"
   about: "关于"
   new_report: "新报告"
   my_reports: "我的报告"
-  shortage_tracker: "短缺追踪器"
-  instruct_body: "在地图上的任意位置按以添加报告。 或者，"
-  instruct_body_2: "使用您的设备位置添加报告"
-  instruct_title: "指示"
-  signin_msg: "请 "
-  signin_msg_2: "将报告添加到地图。"
+  reports:
+   new:
+     new_report: "新报告"
+     back_link_label: "回去"
+   form:
+     latitude: "纬度"
+     longitude: "经度"
+     latlon_notes: "笔记"
+     products_title: "产品展示"
+     add_product_detail: "添加产品详细信息"
+     populate_location_label: "填充位置"
+   product_details_fields:
+     product_label: "产品"
+     scarcity_label: "缺乏"
+     price_label: "价钱"
+     note_label: "笔记"
+     normal_label: "正常"
+     none_label: "没有"
+     expensive_label: "昂贵"
+     select_product_label: "选择产品..."
+     del_product_detail: "删除产品详细信息"     
+   index:
+     report_title: "报告书"
+     report_msg1: "您尚未创建报告。"
+     create_msg: "现在创建您的第一个报告。"
+     location: "位置"
+     notes: "笔记"
+     report_time: "报告时间"
+  maps:
+   index:
+     lang: "zh-CN(简体中文)"
+     login_status: "以 %{username} 身份登录"
+     instruct_body: "在地图上的任意位置按以添加报告。 或者，"
+     instruct_body_2: "使用您的设备位置添加报告"
+     instruct_title: "指示"
+     signin_msg: "请 "
+     signin_msg_2: "将报告添加到地图。"
   activerecord:
     errors:
       messages:

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -1,0 +1,222 @@
+---
+zh-HK:
+  lang: "zh-HK(繁體中文)"
+  sessions:
+     signed_in: "登录成功。"
+     signed_out: "登出成功。"
+     already_signed_out: "登出成功。"
+  signup: "注册"
+  login: "登录"
+  logout: "登出"
+  login_status: "以 %{username} 身份登录"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 驗證失敗︰%{errors}
+        restrict_dependent_destroy:
+          has_one: 由於%{record}依賴此記錄，無法移除
+          has_many: 由於%{record}依賴此記錄，無法移除
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    - 
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約一小時
+        other: 約%{count}小時
+      about_x_months:
+        one: 約一個月
+        other: 約%{count}個月
+      about_x_years:
+        one: 約一年
+        other: 約%{count}年
+      almost_x_years:
+        one: 接近一年
+        other: 接近%{count}年
+      half_a_minute: 半分鐘
+      less_than_x_seconds:
+        one: 不到一秒
+        other: 不到%{count}秒
+      less_than_x_minutes:
+        one: 不到一分鐘
+        other: 不到%{count}分鐘
+      over_x_years:
+        one: 超過一年
+        other: 超過%{count}年
+      x_seconds:
+        one: 一秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 一分鐘
+        other: "%{count}分鐘"
+      x_days:
+        one: 一天
+        other: "%{count}天"
+      x_months:
+        one: 一個月
+        other: "%{count}個月"
+      x_years:
+        one: 一年
+        other: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: 必定要被接受
+      blank: 不可以是空白
+      confirmation: 與 %{attribute} 不一致
+      empty: 不可以留空
+      equal_to: 必須等於 %{count}
+      even: 必須要是雙數
+      exclusion: 是被保留的關鍵字
+      greater_than: 必須大於 %{count}
+      greater_than_or_equal_to: 必須大於或等於 %{count}
+      inclusion: 並非可被接受的內容
+      invalid: 是無效的
+      less_than: 必須小於 %{count}
+      less_than_or_equal_to: 必須小於或等於 %{count}
+      model_invalid: 驗證失敗︰%{errors}
+      not_a_number: 必須是數字
+      not_an_integer: 必須是整數
+      odd: 必須是單數
+      other_than: 不可以是 %{count} 個字
+      present: 必定要是空白
+      required: 必須存在
+      taken: 已被使用
+      too_long:
+        one: 太長（最長為一個字元）
+        other: 太長（最長為 %{count} 個字元）
+      too_short:
+        one: 太短（最少為一個字元）
+        other: 太短（最少為 %{count} 個字元）
+      wrong_length:
+        one: 字數錯誤 (應為一個字元)
+        other: 字數錯誤 (應為 %{count} 個字元)
+    template:
+      body: 以下欄位發生問題︰
+      header:
+        one: 發生一項錯誤，以致 %{model} 未能儲存。
+        other: 發生%{count}項錯誤，以致 %{model} 未能儲存。
+  helpers:
+    select:
+      prompt: 請選擇
+    submit:
+      create: 新增%{model}
+      submit: 儲存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: HK$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百萬
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 和
+      two_words_connector: 和
+      words_connector: "、"
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -5,15 +5,6 @@ zh-CN:
   login: "登录"
   logout: "登出"
   login_status: "以 %{username} 身份登录"
-  about: "关于"
-  new_report: "新报告"
-  my_reports: "我的报告"
-  shortage_tracker: "短缺追踪器"
-  instruct_body: "在地图上的任意位置按以添加报告。 或者，"
-  instruct_body_2: "使用您的设备位置添加报告"
-  instruct_title: "指示"
-  signin_msg: "请 "
-  signin_msg_2: "将报告添加到地图。"
   activerecord:
     errors:
       messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,11 @@ Rails.application.routes.draw do
   devise_for :users
   resources :reports
 
+  scope "(:locale)", locale: /en|ja|zh-HK|zh-CN|zh-TW/ do
+    resources :users, only: [:new, :show]
+#    root  'maps#index'
+  end
+    
   scope '/admin' do
     resources :products
     resources :privileges

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
 
   scope "(:locale)", locale: /en|ja|zh-HK|zh-CN|zh-TW/ do
     resources :users, only: [:new, :show]
-#    root  'maps#index'
   end
     
   scope '/admin' do


### PR DESCRIPTION
Internationalized tracker with tags for English and zh-CN.

Todo: Report list labels is still english by default, although table column name tags have been added to yml files. need to populate products in order to test.

If someone can please check translation for correctness, would be appreciated. Thanks. 